### PR TITLE
이미지 다운 라이브러리 변경

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,14 @@
     "typescriptreact"
   ],
   "editor.tabSize": 2,
-  "cSpell.words": ["chee", "Lomi", "lumi", "lumy", "Romi", "swyg", "Wooka"]
+  "cSpell.words": [
+    "chee",
+    "Kakao",
+    "Lomi",
+    "lumi",
+    "lumy",
+    "Romi",
+    "swyg",
+    "Wooka"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-unused-imports": "^2.0.0",
     "file-saver": "^2.0.5",
     "html-to-image": "^1.11.11",
+    "html2canvas": "^1.4.1",
     "next": "13.1.2",
     "next-seo": "^5.15.0",
     "react": "18.2.0",

--- a/src/component/result/icon-box.tsx
+++ b/src/component/result/icon-box.tsx
@@ -15,14 +15,14 @@ export default function IconBox({ isLoading, onDownloadBtn }: IconBoxProps) {
   const router = useRouter();
 
   const onDownloadClick = () => {
-    // onDownloadBtn()
-    alert(`이 기능은 추후에 서비스 예정입니다. ver.2를 기대해주세요!`);
+    onDownloadBtn();
   };
-  const onShareClick = async () => {
-    // await navigator.clipboard.writeText(window.location.href);
-    // alert('클립보드에 복사되었습니다. ');
 
-    alert(`이 기능은 추후에 서비스 예정입니다. ver.2를 기대해주세요!`);
+  const onShareClick = async () => {
+    await navigator.clipboard.writeText(window.location.href);
+    alert('클립보드에 복사되었습니다. ');
+
+    // alert(`이 기능은 추후에 서비스 예정입니다. ver.2를 기대해주세요!`);
   };
 
   return (

--- a/src/hooks/use-image-download.ts
+++ b/src/hooks/use-image-download.ts
@@ -1,0 +1,37 @@
+import html2canvas from 'html2canvas';
+import { useRef } from 'react';
+
+function useImageDownload() {
+  const captureArea = useRef<HTMLDivElement>(null);
+
+  /* 다운로드 버튼 함수 */
+  const onImageDownload = async () => {
+    if (captureArea.current) {
+      const canvas = await html2canvas(captureArea.current, { scale: 4 });
+      const element = document.createElement('a');
+      element.href = canvas.toDataURL('image/png');
+      element.download = '2023_Mandalart.png';
+      element.click();
+    }
+  };
+
+  // 이미지 blob 형태로 가져오기, 이부분은 아직 미완성, 필요할때 완성할 예정
+  const getImageBlob = async () => {
+    if (captureArea.current) {
+      const canvas = await html2canvas(captureArea.current);
+      canvas.toBlob((blob) => {
+        if (!blob) return;
+        const url = URL.createObjectURL(blob);
+        return url;
+      });
+    }
+  };
+
+  return {
+    captureArea,
+    onImageDownload,
+    getImageBlob,
+  };
+}
+
+export default useImageDownload;

--- a/src/hooks/use-image-download.ts
+++ b/src/hooks/use-image-download.ts
@@ -25,6 +25,7 @@ function useImageDownload() {
         return url;
       });
     }
+    return null;
   };
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,6 +636,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-arraybuffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
@@ -738,6 +743,13 @@ css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz"
   integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
+
+css-line-break@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-2.1.0.tgz#bfef660dfa6f5397ea54116bb3cb4873edbc4fa0"
+  integrity sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==
+  dependencies:
+    utrie "^1.0.2"
 
 css-to-react-native@^3.0.0:
   version "3.1.0"
@@ -1495,6 +1507,14 @@ html-to-image@^1.11.11:
   version "1.11.11"
   resolved "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz"
   integrity sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==
+
+html2canvas@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.1.tgz#7cef1888311b5011d507794a066041b14669a543"
+  integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==
+  dependencies:
+    css-line-break "^2.1.0"
+    text-segmentation "^1.0.3"
 
 ignore@^5.2.0:
   version "5.2.4"
@@ -2359,6 +2379,13 @@ tapable@^2.2.0:
   resolved "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
+text-segmentation@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/text-segmentation/-/text-segmentation-1.0.3.tgz#52a388159efffe746b24a63ba311b6ac9f2d7943"
+  integrity sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==
+  dependencies:
+    utrie "^1.0.2"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
@@ -2453,6 +2480,13 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+utrie@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/utrie/-/utrie-1.0.2.tgz#d42fe44de9bc0119c25de7f564a6ed1b2c87a645"
+  integrity sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==
+  dependencies:
+    base64-arraybuffer "^1.0.2"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## 📄 구현 내용
이미지 다운 라이브러리 변경
 
![2023_Mandalart (5)](https://user-images.githubusercontent.com/49177223/232560441-43b06528-0103-446f-b571-68f50a8ff98c.png)


### ⛱️ 주요 변경 사항

- 이미지 다운 라이브러리 변경
- 이미지 해상도 깨지는 문제 해결
- 아직 이전 라이브러리 삭제하지않음, 정리 필요

### 🤔 참고 링크

- [이미지 해상도 개선기](https://velog.io/@sumi-0011/html2canvas-%EC%9D%B4%EB%AF%B8%EC%A7%80-%ED%95%B4%EC%83%81%EB%8F%84-%EA%B0%9C%EC%84%A0-%EB%B0%A9%EB%B2%95)
